### PR TITLE
code changes for PEN-1315.

### DIFF
--- a/frontend/src/components/common/StudentDetailCommon.vue
+++ b/frontend/src/components/common/StudentDetailCommon.vue
@@ -467,11 +467,23 @@
       ></TwinnedStudentsCard>
     </v-dialog>
     <ConfirmationDialog ref="confirmationDialog"></ConfirmationDialog>
-    <ConfirmationDialog ref="demergeConfirmationDialog">
+    <ConfirmationDialog ref="confirmedStudentUpdateConfirmationDialog">
       <template v-slot:message>
         <v-col class="mt-n6">
           <v-row class="mb-3">
-            Are you sure you want to demerge PENs&nbsp;<strong>{{getMergedFromPen()}}</strong>&nbsp;and&nbsp;<strong>{{getMergedToPen()}}</strong>?
+            Are you sure you want to edit this&nbsp;<strong>Confirmed</strong>&nbsp;student?
+          </v-row>
+        </v-col>
+      </template>
+    </ConfirmationDialog>
+    <ConfirmationDialog ref="demergeConfirmationDialog">
+      <template v-slot:message>
+        <v-col class="mt-n6">
+          <v-row v-if="isConfirmedStudent" class="mb-3">
+            Are you sure you want to de-merge this&nbsp;<strong>Confirmed</strong>&nbsp;student?
+          </v-row>
+          <v-row v-else class="mb-3">
+            Are you sure you want to demerge PENs&nbsp;<strong>{{ getMergedFromPen() }}</strong>&nbsp;and&nbsp;<strong>{{ getMergedToPen() }}</strong>?
           </v-row>
         </v-col>
       </template>
@@ -483,7 +495,7 @@
 import {mapGetters, mapState} from 'vuex';
 import moment from 'moment';
 import ApiService from '../../common/apiService';
-import {REQUEST_TYPES, Routes, STUDENT_CODES, STUDENT_DETAILS_FIELDS} from '@/utils/constants';
+import {REQUEST_TYPES, Routes, STUDENT_CODES, STUDENT_DEMOG_CODES, STUDENT_DETAILS_FIELDS} from '@/utils/constants';
 import StudentDetailsTextField from '@/components/penreg/student/StudentDetailsTextField';
 import StudentDetailsTextFieldReadOnly from '@/components/penreg/student/StudentDetailsTextFieldReadOnly';
 import StudentDetailsComboBox from '@/components/penreg/student/StudentDetailsComboBox';
@@ -613,6 +625,9 @@ export default {
     },
     mergedFrom() {
       return sortBy(this.merges.filter(merge => merge.studentMergeDirectionCode === 'FROM'), ['mergeStudent.pen']);
+    },
+    isConfirmedStudent() {
+      return this.origStudent?.demogCode === STUDENT_DEMOG_CODES.CONFIRMED;
     }
   },
   mounted() {
@@ -896,36 +911,47 @@ export default {
         this.deceasedDialog = true;
       }
     },
-    saveStudent() {
+    async saveStudent() {
       if (this.parentRefs.studentDetailForm.validate()) {
-        const params = {
-          penNumbersInOps: this.origStudent.pen
-        };
-        this.isStudentUpdatedInDifferentTab = false; //make sure that notification for current tab is ignored.
-        ApiService.apiAxios
-          .put(Routes['student'].ROOT_ENDPOINT+'/'+ this.studentID, this.prepPut(this.studentCopy),{params})
-          .then(response => {
-            this.fieldNames.forEach(value => this.enableDisableFieldsMap.set(value, false)); // enable all the fields here, required fields to be disabled will be done in this.setStudent method.
-            this.setStudent(response.data);
-            this.$emit('update:student', response.data);
-            this.setSuccessAlert('Student data updated successfully.');
-          })
-          .catch(error => {
-            if (error?.response?.status === 409 && error?.response?.data?.message) {
-              this.setErrorAlertForStudentUpdate(error?.response?.data?.message);
-              this.isStudentUpdated = true;
-              this.$emit('isStudentUpdated', true);
-              if(this.isStudentUpdatedInDifferentTab){ // if it is already true that means the message has already arrived from STAN.
-                this.setWarningAlertForStudentUpdate(this.lastMessageFromSTANForStudentUpdate);
-              }else {
-                this.isStudentUpdatedInDifferentTab = true; // turn it back to true in case of errors
-              }
-            }else {
-              this.setFailureAlert('Student data could not be updated, please try again.');
-            }
-          })
-          .finally(() => {
-          });
+        let isUpdateStudentAllowed = true;
+        if (this.origStudent?.demogCode === STUDENT_DEMOG_CODES.CONFIRMED) {
+          const confirmation = await this.$refs.confirmedStudentUpdateConfirmationDialog.open(null, null,
+              {color: '#fff', width: 580, closeIcon: true, subtitle: false, dark: false});
+          if (!confirmation) {
+            isUpdateStudentAllowed = false;
+          }
+        }
+        if (isUpdateStudentAllowed) {
+          const params = {
+            penNumbersInOps: this.origStudent.pen
+          };
+          this.isStudentUpdatedInDifferentTab = false; //make sure that notification for current tab is ignored.
+          ApiService.apiAxios
+              .put(Routes['student'].ROOT_ENDPOINT + '/' + this.studentID, this.prepPut(this.studentCopy), {params})
+              .then(response => {
+                this.fieldNames.forEach(value => this.enableDisableFieldsMap.set(value, false)); // enable all the fields here, required fields to be disabled will be done in this.setStudent method.
+                this.setStudent(response.data);
+                this.$emit('update:student', response.data);
+                this.setSuccessAlert('Student data updated successfully.');
+              })
+              .catch(error => {
+                if (error?.response?.status === 409 && error?.response?.data?.message) {
+                  this.setErrorAlertForStudentUpdate(error?.response?.data?.message);
+                  this.isStudentUpdated = true;
+                  this.$emit('isStudentUpdated', true);
+                  if (this.isStudentUpdatedInDifferentTab) { // if it is already true that means the message has already arrived from STAN.
+                    this.setWarningAlertForStudentUpdate(this.lastMessageFromSTANForStudentUpdate);
+                  } else {
+                    this.isStudentUpdatedInDifferentTab = true; // turn it back to true in case of errors
+                  }
+                } else {
+                  this.setFailureAlert('Student data could not be updated, please try again.');
+                }
+              })
+              .finally(() => {
+              });
+        }
+
       }
     },
     prepPut(student) {

--- a/frontend/src/components/penreg/student/StudentAuditHistoryDetailPanel.vue
+++ b/frontend/src/components/penreg/student/StudentAuditHistoryDetailPanel.vue
@@ -60,7 +60,7 @@
 <script>
 import {mapGetters, mapState} from 'vuex';
 import moment from 'moment';
-import {STUDENT_DETAILS_FIELDS} from '@/utils/constants';
+import {STUDENT_CODES, STUDENT_DEMOG_CODES, STUDENT_DETAILS_FIELDS} from '@/utils/constants';
 import PrimaryButton from '../../util/PrimaryButton';
 import {formatPen, formatPostalCode} from '@/utils/format';
 import alertMixin from '../../../mixins/alertMixin';
@@ -145,10 +145,10 @@ export default {
       }
     },
     isSplitPenDisabled() {
-      return this.studentHistory?.totalElements === 1 || !this.studentDetailForRevert || this.hasSagaInProgress;
+      return this.studentHistory?.totalElements === 1 || !this.studentDetailForRevert || this.hasSagaInProgress || this.student?.statusCode === STUDENT_CODES.MERGED;
     },
     isRevertDisabled() {
-      return this.studentHistory?.content?.length === 1 || this.hasSagaInProgress;
+      return this.studentHistory?.content?.length === 1 || this.hasSagaInProgress || this.student?.demogCode === STUDENT_DEMOG_CODES.CONFIRMED || this.student?.statusCode === STUDENT_CODES.MERGED;
     },
     hasSagaInProgress() {
       return this.student && (this.student.sagaInProgress || this.studentsInProcess.has(this.student.studentID));

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -235,6 +235,12 @@ export const STUDENT_CODES = Object.freeze(
     MERGED: 'M'
   }
 );
+export const STUDENT_DEMOG_CODES = Object.freeze(
+  {
+    ACTIVE: 'A',
+    CONFIRMED: 'C'
+  }
+);
 export const PEN_REQ_BATCH_STUDENT_REQUEST_CODES = Object.freeze(
   {
     FIXABLE: 'FIXABLE',


### PR DESCRIPTION
For Merged students:
Revert and Split buttons are disabled on Audit Details screen

For Confirmed students (DEMOG_CD = C)
Revert button is disabled for all records on Audit Details screen
Split button remains enabled on Audit Details screen
When user updates the demographics, a confirmation message is displayed when user clicks on Save; Cancel stops Save, Confirm continues with Save.
When user de-merges, a confirmation message is displayed when user clicks on Save; Cancel stops Save, Confirm continues with Save.