### PR TITLE
Feature/pen 1794 Option for Secure Message

### DIFF
--- a/frontend/src/components/DashboardTable.vue
+++ b/frontend/src/components/DashboardTable.vue
@@ -4,8 +4,7 @@
       <v-col class="pa-0" cols="2">
         <v-card-title class="pa-0">
           <h3>
-            <v-row no-gutters>{{ requestType }}</v-row>
-            <v-row no-gutters>Requests</v-row>
+            <v-row no-gutters class="dashboard-title mr-4">{{ title }}</v-row>
           </h3>
         </v-card-title>
       </v-col>
@@ -46,7 +45,7 @@ export default {
       type: Array,
       required: true
     },
-    requestType: {
+    title: {
       type: String,
       required: false
     },
@@ -120,5 +119,8 @@ export default {
 <style scoped>
   .listCol {
     align-self: center;
+  }
+  .dashboard-title {
+    word-break: break-word;
   }
 </style>

--- a/frontend/src/components/DashboardTable.vue
+++ b/frontend/src/components/DashboardTable.vue
@@ -9,9 +9,11 @@
         </v-card-title>
       </v-col>
       <v-col v-for="(row, index) in tableData" :key="index" class="py-0" cols="3">
-        <v-row class="pa-0"><h3>{{ row.title }}</h3></v-row>
+        <v-row class="pa-0">
+          <h3>{{ row.title }}</h3>
+        </v-row>
         <v-row v-for="(col, idx) in omit(row, 'title')" :key="idx" class="pt-2 listCol">
-           <div v-if="idx==='heldReview' && col > 0">
+          <div v-if="idx === 'heldReview' && col > 0">
             <router-link to="heldRequestBatch">
               <strong>{{ col.data }} {{ col.name }}</strong>
             </router-link>
@@ -22,10 +24,11 @@
     </v-row>
     <v-row class="pt-4 px-8">
       <v-col cols="2"></v-col>
-      <v-col v-for="(row, index) in tableData" :key="index" class="pt-4 py-0 px-0" cols="3">
-        <router-link :to="row.buttonRoute">
+      <v-col
+        v-for="(row, index) in tableData" :key="index" class="pt-4 py-0 px-0" cols="3">
+        <router-link :to="row.button.route">
           <PrimaryButton :id="row.title.replace(/ /g,'')+'Btn'"
-                         :text="'View ' + buttonWording(row.title)"></PrimaryButton>
+                         :text="row.button.text"></PrimaryButton>
         </router-link>
       </v-col>
     </v-row>
@@ -56,14 +59,6 @@ export default {
     PrimaryButton
   },
   methods: {
-    buttonWording(title){
-      if(title.toUpperCase().includes('GET')) {
-        return 'GMP';
-      } else if (title.toUpperCase().includes('UPDATE')) {
-        return 'UMP';
-      }
-      return title;
-    },
     omit(object, key) {
       return omit(object, key);
     },
@@ -72,10 +67,10 @@ export default {
 </script>
 
 <style scoped>
-  .listCol {
-    align-self: center;
-  }
-  .dashboard-title {
-    word-break: break-word;
-  }
+.listCol {
+  align-self: center;
+}
+.dashboard-title {
+  word-break: break-word;
+}
 </style>

--- a/frontend/src/components/DashboardTable.vue
+++ b/frontend/src/components/DashboardTable.vue
@@ -11,19 +11,19 @@
       <v-col v-for="(row, index) in tableData" :key="index" class="py-0" cols="3">
         <v-row class="pa-0"><h3>{{ row.title }}</h3></v-row>
         <v-row v-for="(col, idx) in omit(row, 'title')" :key="idx" class="pt-2 listCol">
-          <div v-if="idx==='heldReview' && col > 0">
+           <div v-if="idx==='heldReview' && col > 0">
             <router-link to="heldRequestBatch">
-              <strong>{{ col }} {{ dataColWording(idx) }}</strong>
+              <strong>{{ col.data }} {{ col.name }}</strong>
             </router-link>
           </div>
-          <div v-else-if="!row.error">{{ col }} {{ dataColWording(idx) }}</div>
+          <div v-else-if="!row.error">{{ col.data }} {{ col.name }}</div>
         </v-row>
       </v-col>
     </v-row>
     <v-row class="pt-4 px-8">
       <v-col cols="2"></v-col>
       <v-col v-for="(row, index) in tableData" :key="index" class="pt-4 py-0 px-0" cols="3">
-        <router-link :to="routeTo(row.title)">
+        <router-link :to="row.buttonRoute">
           <PrimaryButton :id="row.title.replace(/ /g,'')+'Btn'"
                          :text="'View ' + buttonWording(row.title)"></PrimaryButton>
         </router-link>
@@ -35,7 +35,6 @@
 </template>
 <script>
 import omit from 'lodash/omit';
-import {REQUEST_TYPES} from '@/utils/constants';
 import PrimaryButton from './util/PrimaryButton';
 
 export default {
@@ -65,53 +64,9 @@ export default {
       }
       return title;
     },
-    dataColWording(key) {
-      let wording = '';
-      switch(key) {
-      case 'pending':
-        wording = 'submissions pending';
-        break;
-      case 'fixable':
-        wording = 'fixable records';
-        break;
-      case 'repeats':
-        wording = 'repeated records';
-        break;
-      case 'unarchived':
-        wording = 'unarchived submissions';
-        break;
-      case 'initial':
-        wording = 'initial review';
-        break;
-      case 'subsequent':
-        wording = 'subsequent review';
-        break;
-      case 'loadFailed':
-        wording = 'submissions failed';
-        break;
-      case 'heldReview':
-        wording = 'submission held for review';
-        break;
-      }
-      return wording;
-    },
     omit(object, key) {
       return omit(object, key);
     },
-    routeTo(title) {
-      switch (this.buttonWording(title)) {
-      case 'K-12':
-        return REQUEST_TYPES.penRequestBatch.path + '?schoolGroup=' + 'K12';
-      case 'PSI':
-        return REQUEST_TYPES.penRequestBatch.path + '?schoolGroup=' + 'PSI';
-      case 'Errors':
-        return REQUEST_TYPES.failedRequestBatch.path;
-      case 'GMP':
-        return REQUEST_TYPES.penRequest.path;
-      case 'UMP':
-        return REQUEST_TYPES.studentRequest.path;
-      }
-    }
   }
 };
 </script>

--- a/frontend/src/components/Home.vue
+++ b/frontend/src/components/Home.vue
@@ -186,7 +186,7 @@ export default {
       ApiService.apiAxios.get(Routes.penRequestBatch.STATS_URL).then(response => {
         this.penRequestData.push({
           title: 'K-12',
-          buttonRoute: REQUEST_TYPES.penRequestBatch.path + '?schoolGroup=' + 'K12',
+          button: {route: REQUEST_TYPES.penRequestBatch.path + '?schoolGroup=' + 'K12', text: 'View K-12'},
           pending: {data: response.data.K12.pending, name: 'submission pending'},
           fixable: {data: response.data.K12.fixable, name: 'fixable records'},
           repeats: {data: response.data.K12.repeats, name: 'repeated records'},
@@ -194,7 +194,7 @@ export default {
         });
         this.penRequestData.push({
           title: 'PSI',
-          buttonRoute: REQUEST_TYPES.penRequestBatch.path + '?schoolGroup=' + 'PSI',
+          button: {route: REQUEST_TYPES.penRequestBatch.path + '?schoolGroup=' + 'PSI', text: 'View PSI'},
           pending: {data: response.data.PSI.pending, name: 'submissions pending'},
           fixable: {data: response.data.PSI.fixable, name: 'fixable records'},
           repeats: {data: response.data.PSI.repeats, name: 'repeated records'},
@@ -203,7 +203,7 @@ export default {
         });
         this.penRequestData.push({
           title: 'Errors',
-          buttonRoute: REQUEST_TYPES.failedRequestBatch.path,
+          button: {route: REQUEST_TYPES.failedRequestBatch.path, text: 'View Errors'},
           loadFailed: {data: response.data.ERROR.loadFailed, name: 'submissions failed'},
         });
       }).finally(() => {
@@ -221,9 +221,9 @@ export default {
       responses.forEach((response)=>{
         let titleAndButtonRoute;
         if(response.value.config.url === Routes.penRequest.STATS_URL) {
-          titleAndButtonRoute = {title: 'Get My PEN', buttonRoute: REQUEST_TYPES.penRequest.path};
+          titleAndButtonRoute = {title: 'Get My PEN', button: {route: REQUEST_TYPES.penRequest.path, text: 'View GMP'}};
         } else {
-          titleAndButtonRoute = {title: 'Update My PEN', buttonRoute: REQUEST_TYPES.studentRequest.path};
+          titleAndButtonRoute = {title: 'Update My PEN', button: {route: REQUEST_TYPES.studentRequest.path, text: 'View UMP'}};
         }
         if(response.status === 'fulfilled') {
           this.studentData.push({
@@ -246,7 +246,7 @@ export default {
     //TODO: replace this with API call for secure messaging
     this.secMessageData.push({
       title: 'PEN Team Inbox',
-      buttonRoute: 'insert some route here',
+      button: {route: 'insert some route here', text: 'View Inbox'},
     });
 
     setTimeout(() => this.isLoadingSecMessage = false, 1000);

--- a/frontend/src/components/Home.vue
+++ b/frontend/src/components/Home.vue
@@ -2,7 +2,7 @@
   <div>
     <v-row class="pb-6">
       <v-col cols="8" v-if="VIEW_EDIT_PEN_REQUEST_BATCH_FILES_ROLE">
-        <DashboardTable v-if="!isLoadingBatch" requestType="School" colour="#CED6E2"
+        <DashboardTable v-if="!isLoadingBatch" title="School Requests" colour="#CED6E2"
                         :tableData="penRequestData"></DashboardTable>
         <v-container v-else-if="isLoadingBatch" class="full-height" fluid>
           <article id="pen-display-container" class="top-banner full-height">
@@ -78,7 +78,7 @@
         </v-card>
       </v-col>
       <v-col cols="8" v-if="(VIEW_GMP_REQUESTS_ROLE || VIEW_UMP_REQUESTS_ROLE)">
-        <DashboardTable v-if="!isLoadingGmpUmp" requestType="Student" colour="#F2F2F2" :tableData="studentData"></DashboardTable>
+        <DashboardTable v-if="!isLoadingGmpUmp" title="Student Requests" colour="#F2F2F2" :tableData="studentData"></DashboardTable>
         <v-container fluid class="full-height" v-else-if="isLoadingGmpUmp">
           <article id="pen-display-container" class="top-banner full-height">
             <v-row align="center" justify="center">


### PR DESCRIPTION
Created UI for Dashboard.vue for secure messages. Looks like: 
![image](https://user-images.githubusercontent.com/74216496/144277380-1ac6b0d0-2a82-4b29-aa6a-90f5f0f6643a.png)

Refactored DashboardTable.vue to remove switch logic for setting the titles and button names/route.

these are now set based on the following object structure. 
          title: 'K-12', `sets title for the side`
          button: { `this will set the button route and the display text`
            route: REQUEST_TYPES.penRequestBatch.path + '?schoolGroup=' + 'K12', 
            text: 'View K-12'
          },
          pending: {data: response.data.K12.pending, name: 'submission pending'}, `the row name is set with name property`
          fixable: {data: response.data.K12.fixable, name: 'fixable records'}, `data will refer to the number of records`
          repeats: {data: response.data.K12.repeats, name: 'repeated records'},
          unarchived: {data: response.data.K12.unarchived, name: 'unarchived submissions'}

Missing features are marked with a TODO comment. eg. missing button route for secure messages and role requirement. 

I considered using vue Slots, but had trouble wrapping my head around using slots within for loops. 