### PR TITLE
pen-1912 bug fix link not being rendered when there are files held for review

### DIFF
--- a/frontend/src/components/DashboardTable.vue
+++ b/frontend/src/components/DashboardTable.vue
@@ -13,7 +13,7 @@
           <h3>{{ row.title }}</h3>
         </v-row>
         <v-row v-for="(col, idx) in omit(row, 'title')" :key="idx" class="pt-2 listCol">
-          <div v-if="idx === 'heldReview' && col > 0">
+          <div v-if="idx === 'heldReview' && col.data > 0">
             <router-link to="heldRequestBatch">
               <strong>{{ col.data }} {{ col.name }}</strong>
             </router-link>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/74216496/149990299-191b7097-2a3a-4cce-9c23-a6d8258b5203.png)

Link now shows when number of reviews > 1. 