### PR TITLE
Fix select boxes in Details view.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,6 +97,7 @@
       "vue/no-unused-vars": 0,
       "vue/valid-v-slot": 0,
       "vue/no-reserved-component-names": 0,
+      "vue/v-on-event-hyphenation": 0,
       "no-console": "off",
       "eol-last": [
         "error",

--- a/frontend/src/components/institute/SchoolDetails.vue
+++ b/frontend/src/components/institute/SchoolDetails.vue
@@ -154,7 +154,7 @@
                 <v-window-item value="details">
                   <Details
                     :school-i-d="schoolID"
-                    @updateSchool="updateSchoolDetails"
+                    @update-school="updateSchoolDetails"
                   />
                 </v-window-item>
                 <v-window-item value="contacts">

--- a/frontend/src/components/institute/common/Details.vue
+++ b/frontend/src/components/institute/common/Details.vue
@@ -356,6 +356,7 @@
                     class="mt-n5"
                     multiple
                     required
+                    @update:model-value="sortSelectedGrades"
                   />
                 </v-col>
               </v-row>
@@ -485,7 +486,7 @@
                     variant="underlined"
                     label="NLC Activity"
                     multiple
-                    @update:model-value="sortNLC"
+                    @update:model-value="sortSelectedNLC"
                   />
                 </v-col>
               </v-row>
@@ -1365,8 +1366,15 @@ export default {
         .map(selected => this.schoolNeighborhoodLearningTypes
           .find(nlt => nlt.neighborhoodLearningTypeCode === selected));
     },
-    sortNLC() {
+    sortSelectedNLC() {
       this.selectedNLC = this.selectedNLC.toSorted();
+    },
+    sortSelectedGrades() {
+      this.selectedGradeTypes = this.selectedGradeTypes.toSorted((a, b) => {
+        const typeA = this.schoolGradeTypes.find(gt => gt.schoolGradeCode === a).displayOrder;
+        const typeB = this.schoolGradeTypes.find(gt => gt.schoolGradeCode === b).displayOrder;
+        return typeA - typeB;
+      });
     },
     saveNewSchoolNote() {
       this.loading = true;
@@ -1486,9 +1494,10 @@ export default {
     async toggleEdit() {
       this.schoolDetailsCopy = this.deepCloneObject(this.school);
       this.addAddressesIfRequired(this.schoolDetailsCopy);
-      this.sortNLC();
       this.populateSelectedGrades(this.school.grades);
       this.populateSelectedNLC(this.school.neighborhoodLearning);
+      this.sortSelectedNLC();
+      this.sortSelectedGrades();
       this.showAddress = this.hasMailingAddress();
       this.editing = !this.editing;
       await this.$nextTick();
@@ -1498,7 +1507,8 @@ export default {
       this.schoolDetailsCopy = this.deepCloneObject(this.school);
       this.addAddressesIfRequired(this.schoolDetailsCopy);
       this.showAddress = true;
-      this.sortNLC();
+      this.sortSelectedNLC();
+      this.sortSelectedGrades();
       this.editing = !this.editing;
       await this.$nextTick();
       this.$refs.schoolDetailsForm.validate();

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -100,3 +100,14 @@ export function formatDisplayDate(date) {
 export function formatContactName(contact) {
   return contact.firstName ? `${contact.firstName} ${contact.lastName}` : contact.lastName;
 }
+
+export function formatVSelectOption({ title, value }) {
+  return obj => {
+    if (obj[title] === undefined || obj[value] === undefined) {
+      console.warn('Undefined values in VSelectOption', obj);
+      console.warn(`Make sure the ${title} and ${value} accessors exist`);
+    }
+
+    return { title: obj[title], value: obj[value] };
+  };
+}


### PR DESCRIPTION
Changes upstream in Vuetify 3.3.23 have broken our v-selects due to the simple fact that they no longer map to their `:items` prop, but rather, their `v-model` binding.

This PR fixes this issue by taking control over the v-model by mapping it to the expected data when populating the field values, and updating the payload before sending it.

Ref: https://github.com/bcgov/EDUC-STUDENT-ADMIN/pull/1627/commits/6e54d81405f458d149362d71759d8b764c552cc7