### PR TITLE
adding functionality to input macroCode when creating a new macro

### DIFF
--- a/backend/src/components/macro.js
+++ b/backend/src/components/macro.js
@@ -1,10 +1,9 @@
 'use strict';
 const config = require('../config/index');
-const {getData, postData, getUser, logApiError, errorResponse, stripAuditColumns, addSagaStatusToRecords} = require('./utils');
+const { postData, getUser, logApiError, errorResponse, stripAuditColumns, addSagaStatusToRecords} = require('./utils');
 const redisUtil = require('../util/redis/redis-utils');
 const log = require('./logger');
 const SAGAS = require('./saga');
-const { randomInt } = require('crypto');
 
 async function updateMacroByMacroId(req, res) {
   try {
@@ -21,32 +20,12 @@ async function updateMacroByMacroId(req, res) {
   }
 }
 
-function genRandomMacroCode(length = 3) {
-  let result = '';
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-  const charsLength = chars.length;
-  for ( let i = 0; i < length; i++ ) {
-    result += chars.charAt(randomInt(charsLength));
-  }
-  return result;
-}
-
-function createMacroCode(macros) {
-  let macroCode;
-  do {
-    macroCode = genRandomMacroCode();
-  } while(macros.some(macro => macro.macroCode === macroCode));
-  return macroCode;
-}
-
 async function createMacro(req, res) {
   try {
     const newMacro = req.body;
     stripAuditColumns(newMacro);
 
     const penMacroURL = config.get('server:macro:penMacroURL');
-    const currentMacros = await getData(`${penMacroURL}?businessUseTypeCode=${newMacro.businessUseTypeCode}&macroTypeCode=${newMacro.macroTypeCode}`);
-    newMacro.macroCode = createMacroCode(currentMacros);
     
     const sagaId = await postData(`${penMacroURL}/create-macro`, newMacro, null, getUser(req).idir_username);
 

--- a/backend/tests/unit/components/macro.spec.js
+++ b/backend/tests/unit/components/macro.spec.js
@@ -46,9 +46,9 @@ describe('updateMacroByMacroId', () => {
     expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
     expect(res.json).toHaveBeenCalledWith('sagaId');
   });
-  it('should return INTERNAL_SERVER_ERROR if putData exceptions thrown', async () => {
-    utils.putData.mockRejectedValue(new ApiError('test error senario'))
-    await macro.createMacro(req, res);
+  it('should return INTERNAL_SERVER_ERROR if postData exceptions thrown', async () => {
+    utils.postData.mockRejectedValue(new ApiError('test error senario'))
+    await macro.updateMacroByMacroId(req, res);
     expect(res.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
   });
 });
@@ -83,11 +83,6 @@ describe('createMacro', () => {
     }, SAGAS.MACRO.sagaEventRedisKey);
     expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
     expect(res.json).toHaveBeenCalledWith('sagaId');
-  });
-  it('should return INTERNAL_SERVER_ERROR if getData exceptions thrown', async () => {
-    utils.getData.mockRejectedValue(new ApiError('test error senario'));
-    await macro.createMacro(req, res);
-    expect(res.status).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR);
   });
   it('should return INTERNAL_SERVER_ERROR if postData exceptions thrown', async () => {
     utils.postData.mockRejectedValue(new ApiError('test error senario'))

--- a/frontend/src/components/admin/AddMacro.vue
+++ b/frontend/src/components/admin/AddMacro.vue
@@ -1,0 +1,106 @@
+<template>
+  <div>
+    <v-form ref="addMacroForm">
+      <v-row>
+        <v-col>
+          <v-text-field
+            v-model="macro.macroCode"
+            maxlength="3"
+            label="Macro Code"
+            density="compact"
+            :rules="[Rules.required(), Rules.minLength(3)]"
+            :disabled="loading || disabled"
+            variant="outlined"
+            auto-hide="true"
+            @input="(event) => {isFormValid(); changeInputToUpperCase(event)}"
+          />
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col>
+          <v-textarea
+            v-model="macro.macroText"
+            maxlength="4000"
+            label="Macro Message"
+            density="compact"
+            variant="outlined"
+            :disabled="loading || disabled"
+            :rules="[Rules.required()]"
+            :rows="rows"
+            @input="isFormValid"
+          />
+        </v-col>
+      </v-row>
+    </v-form>
+
+    <v-card-actions class="pt-0">
+      <v-spacer />
+      <PrimaryButton
+        id="cancel-action"
+        class="mr-2"
+        :short="short"
+        secondary
+        text="Cancel"
+        :disabled="loading || disabled"
+        @click-action="$emit('cancel')"
+      />
+      <PrimaryButton
+        id="save-action"
+        :short="short"
+        text="Save"
+        :disabled="loading || disabled || !isValidForm"
+        :loading="loading"
+        @click-action="$emit('save', macro)"
+      />
+    </v-card-actions>
+  </div>
+</template>
+
+<script>
+import PrimaryButton from '../util/PrimaryButton.vue';
+import * as Rules from '../../utils/institute/formRules';
+
+export default {
+  name: 'MacroEditor',
+  components: {
+    PrimaryButton,
+  },
+  props: {
+    macro: {
+      type: Object,
+      required: true
+    },
+    rows: {
+      type: String,
+      default: '4'
+    },
+    short: {
+      type: Boolean,
+      default: false
+    },
+    loading: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['save', 'cancel'],
+  data: () => ({
+    isValidForm: false,
+    Rules,
+  }),
+  methods:{
+    isFormValid() {
+      this.isValidForm = this.$refs?.addMacroForm?.isValid;
+    },
+    changeInputToUpperCase(event) {
+      //converts all input into upper case letters
+      const input = event.target.value.toUpperCase().replace(/[^A-Z]/g, '');
+      this.macro.macroCode = input;
+    }
+  }
+};
+</script>

--- a/frontend/src/components/admin/MacrosDisplay.vue
+++ b/frontend/src/components/admin/MacrosDisplay.vue
@@ -105,6 +105,7 @@
           density="compact"
           color="#FFF"
           flat
+          title="Add Macro"
         >
           <v-spacer />
           <v-btn
@@ -118,7 +119,7 @@
             </v-icon>
           </v-btn>
         </v-toolbar>
-        <MacroEditor
+        <AddMacro
           class="pb-4 px-4"
           :macro="newMacro"
           rows="10"
@@ -149,6 +150,7 @@ import alertMixin from '@/mixins/alertMixin';
 import {deepCloneObject} from '@/utils/common';
 import ConfirmationDialog from '../util/ConfirmationDialog.vue';
 import MacroEditor from './MacroEditor.vue';
+import AddMacro from './AddMacro.vue';
 import _ from 'lodash';
 import {notificationsStore} from '@/store/modules/notifications';
 import {edxStore} from '@/store/modules/edx';
@@ -162,7 +164,8 @@ export default {
   components: {
     PrimaryButton,
     ConfirmationDialog,
-    MacroEditor
+    MacroEditor,
+    AddMacro
   },
   mixins: [alertMixin],
   beforeRouteLeave(to, from, next) {

--- a/frontend/src/utils/institute/formRules.js
+++ b/frontend/src/utils/institute/formRules.js
@@ -175,6 +175,20 @@ const website = (message = 'Website must be valid and secure (i.e., https)') => 
   return v => !v || /^https:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)$/.test(v) || message;
 };
 
+/**
+ * Rule to check minimum length
+ * @param {Number} length
+ * @param {String} message
+ * @returns Function
+ */
+const minLength = ( length, message = 'Must be at least ${length} characters') => {
+  if (!message.includes('${length}')) {
+    console.warn('missing ${length} string in message for minLength rule');
+  }
+  message = message.replace('${length}', length.toString());
+  return v => !v || v.length === length || message;
+};
+
 export {
   email,
   endDateRule,
@@ -185,6 +199,7 @@ export {
   noSpecialCharactersContactName,
   noSpecialCharactersContactTitle,
   noSpecialCharactersAddress,
+  minLength,
   specialCharactersInSchDisName,
   phoneNumber,
   postalCode,


### PR DESCRIPTION
These are part of some newPen upgrades that were requested by business.

Changes for macros to allow user to enter in a 3 digit code. The Macro API will check to ensure that the Macro isn't duplicated before starting the Saga. 

So I removed the duplicates check in NodeJs. 

Happy state
![image](https://github.com/bcgov/EDUC-STUDENT-ADMIN/assets/74216496/0a851d45-eff9-4f80-981a-256840276847)

Error state
![image](https://github.com/bcgov/EDUC-STUDENT-ADMIN/assets/74216496/c47b3378-df76-42e5-9c69-a41891906c49)



