### PR TITLE
HD-26606 fixing tool tips and memo icons. Note vw doesn't work for max-width a…

### DIFF
--- a/frontend/src/components/admin/stats/MergedStudentsStatsDataTable.vue
+++ b/frontend/src/components/admin/stats/MergedStudentsStatsDataTable.vue
@@ -85,10 +85,13 @@
               v-if="header.bottomValue === 'memo'"
               bottom
             >
-              <template #activator="{ on }">
-                <span class="bottom-column-item">{{
-                    firstMemoChars(item.item.raw[header.bottomValue])
-                  }}</span>
+              <template #activator="{ props }">
+                <span
+                  v-bind="props"
+                  class="bottom-column-item"
+                >
+                  {{ firstMemoChars(item.item.raw[header.bottomValue]) }}
+                </span>
               </template>
               <span>{{ item.item.raw[header.bottomValue] }}</span>
             </v-tooltip>

--- a/frontend/src/components/common/PenMatchResultsTable.vue
+++ b/frontend/src/components/common/PenMatchResultsTable.vue
@@ -128,13 +128,16 @@
                         </span>
                         <v-tooltip
                           v-if="item.item.raw['memo']"
-                          top
-                          max-width="40vw"
+                          location="top"
+                          max-width="500px"
                         >
-                          <template #activator="{ on }">
-                            <v-icon class="mx-1">
-                              sticky_note_2
-                            </v-icon>
+                          <template #activator="{ props }">
+
+                            <v-icon
+                              icon="mdi-note-text"
+                              class="mx-1"
+                              v-bind="props"
+                            />
                           </template>
                           <span>
                             {{ item.item.raw['memo'] }}

--- a/frontend/src/components/data-collection/PenMatchResults.vue
+++ b/frontend/src/components/data-collection/PenMatchResults.vue
@@ -147,13 +147,15 @@
                         </span>
                         <v-tooltip
                           v-if="item.item.raw['memo']"
-                          top
-                          max-width="40vw"
+                          location="top"
+                          max-width="500px"
                         >
-                          <template #activator="{ on }">
-                            <v-icon class="mx-1">
-                              sticky_note_2
-                            </v-icon>
+                          <template #activator="{ props }">
+                            <v-icon
+                              v-bind="props"
+                              icon="mdi-note-text"
+                              class="mx-1"
+                            />
                           </template>
                           <span>
                             {{ item.item.raw['memo'] }}

--- a/frontend/src/components/nominal-roll/NomRollStudentSearchResults.vue
+++ b/frontend/src/components/nominal-roll/NomRollStudentSearchResults.vue
@@ -147,8 +147,8 @@
                   v-if="header.value === 'mincode'"
                   right
                 >
-                  <template #activator="{ on }">
-                    <span>{{ item.item.raw[header.value] }}</span>
+                  <template #activator="{ props }">
+                    <span v-bind="props">{{ item.item.raw[header.value] }}</span>
                   </template>
                   <span>{{ getSchoolName(item.item.raw) }}</span>
                 </v-tooltip>
@@ -166,8 +166,8 @@
                   style="color: red"
                 >
                   {{ formatTableColumn(header.format, item.item.raw[header.value]) }}
-                  <v-tooltip bottom>
-                    <template #activator="{ on, props }">
+                  <v-tooltip location="bottom">
+                    <template #activator="{ props }">
                       <v-icon
                         color="red"
                         size="small"

--- a/frontend/src/components/penreg/penrequest-batch/PenRequestBatchDataTable.vue
+++ b/frontend/src/components/penreg/penrequest-batch/PenRequestBatchDataTable.vue
@@ -80,7 +80,7 @@
                 />
                 <v-tooltip
                   v-if="item.item.raw.sagaInProgress"
-                  bottom
+                  location="bottom"
                 >
                   <template #activator="{ props }">
                     <v-icon
@@ -127,13 +127,14 @@
               <span v-else>{{ formatTableColumn(header.format, item.item.raw[header.value]) }}</span>
               <v-tooltip
                 v-if="header.value==='mincode' && isUnarchived(item.item.raw)"
-                right
+                location="end"
               >
-                <template #activator="{ on }">
+                <template #activator="{ props }">
                   <v-icon
                     small
                     color="#2E8540"
                     class="ml-1"
+                    v-bind="props"
                   >
                     {{ isUnarchivedBatchChanged(item.item.raw) ? 'mdi-sync' : 'mdi-lock-open-outline' }}
                   </v-icon>
@@ -144,10 +145,11 @@
                 v-if="header.value==='mincode' && isRearchived(item.item.raw)"
                 right
               >
-                <template #activator="{ on }">
+                <template #activator="{ props }">
                   <v-icon
                     color="#2E8540"
                     class="ml-1"
+                    v-bind="props"
                   >
                     {{ 'preview' }}
                   </v-icon>

--- a/frontend/src/components/penreg/penrequest-batch/PrbStudentSearchResults.vue
+++ b/frontend/src/components/penreg/penrequest-batch/PrbStudentSearchResults.vue
@@ -131,10 +131,10 @@
                 >{{ item.item.raw[header.topValue] }}</a>
                 <v-tooltip
                   v-else-if="header.topValue === 'mincode'"
-                  right
+                  location="end"
                 >
-                  <template #activator="{ on }">
-                    <span>{{ item.item.raw[header.topValue] }}</span>
+                  <template #activator="{ props }">
+                    <span v-bind="props">{{ item.item.raw[header.topValue] }}</span>
                   </template>
                   <span>{{ getSchoolName(item.item.raw) }}</span>
                 </v-tooltip>

--- a/frontend/src/components/penreg/student-search/StudentAdvancedSearch.vue
+++ b/frontend/src/components/penreg/student-search/StudentAdvancedSearch.vue
@@ -351,7 +351,7 @@
             />
           </v-col>
           <v-col cols="2">
-            <v-tooltip left>
+            <v-tooltip location="start">
               <template #activator="{ props }">
                 <v-icon
                   size="25"

--- a/frontend/src/components/penreg/student-search/StudentSearchResults.vue
+++ b/frontend/src/components/penreg/student-search/StudentSearchResults.vue
@@ -127,10 +127,14 @@
               <!-- if top and bottom value are the same, do not display the bottom value -->
               <v-tooltip
                 v-if="header.bottomValue === 'memo'"
-                bottom
+                location="bottom"
               >
-                <template #activator="{ on }">
-                  <span class="bottom-column-item">{{
+                <template #activator="{ props }">
+                  <span
+                    v-bind="props"
+                    class="bottom-column-item"
+                  >
+                    {{
                       firstMemoChars(item.item.raw[header.bottomValue])
                     }}</span>
                 </template>

--- a/frontend/src/components/penreg/student/TwinnedStudentsCard.vue
+++ b/frontend/src/components/penreg/student/TwinnedStudentsCard.vue
@@ -78,9 +78,9 @@
           </a>
         </template>
         <template #[`item.matchedReason`]="props">
-          <v-tooltip bottom>
-            <template #activator="{ on }">
-              <span>{{ props.value }}</span>
+          <v-tooltip location="bottom">
+            <template #activator="{ props: tooltipProps }">
+              <span v-bind="tooltipProps">{{ props.value }}</span>
             </template>
             <span>{{ matchReasonLabel(props.value) }}</span>
           </v-tooltip>

--- a/frontend/src/components/ump/StudentRequestCard.vue
+++ b/frontend/src/components/ump/StudentRequestCard.vue
@@ -33,7 +33,7 @@
           v-if="request.recordedPen"
           v-model="clipboard"
           class="mb-2"
-          right
+          location="end"
         >
           <template #activator="{ }">
             <PrimaryButton


### PR DESCRIPTION
fixing tool tips and memo icons. Note vw doesn't work for max-width anymore. Ended up using pixels instead

noted that { on } has been replaced with { props } and v-bind on the tooltip. 

Pen request batch match results
![image](https://github.com/user-attachments/assets/1976bcf5-d5f3-4208-8db1-618f9a2a2b62)

student search results 
![image](https://github.com/user-attachments/assets/2b78489d-459b-4375-a0bb-142ef477d636)

